### PR TITLE
[FIX] web_widget_x2many_2d_matrix: Do not fail when using float_time …

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
@@ -9,11 +9,6 @@
                 showColumnTotals="props.showColumnTotals"
                 readonly="props.readonly"
                 domain="props.domain"
-                canOpen="props.canOpen"
-                canCreate="props.canCreate"
-                canWrite="props.canWrite"
-                canQuickCreate="props.canQuickCreate"
-                canCreateEdit="props.canCreateEdit"
                 x2mListColumns="props.x2mListColumns"
             />
         </div>

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -171,11 +171,6 @@ export class X2Many2DMatrixRenderer extends Component {
             readonly: this.props.readonly,
             record: record,
             name: this.matrixFields.value,
-            canCreate: this.props.canCreate,
-            canOpen: this.props.canOpen,
-            canWrite: this.props.canWrite,
-            canQuickCreate: this.props.canQuickCreate,
-            canCreateEdit: this.props.canCreateEdit,
         };
         if (record) {
             const domain = record.fields[this.matrixFields.value].domain;


### PR DESCRIPTION
This PR seems to fix following error:

```
UncaughtPromiseError > OwlError
Uncaught Promise > Invalid props for component 'X2ManyField': unknown key 'canCreate', unknown key 'canOpen', unknown key 'canWrite', unknown key 'canQuickCreate', unknown key 'canCreateEdit', 'context' is missing (should be a object)
OwlError: Invalid props for component 'X2ManyField': unknown key 'canCreate', unknown key 'canOpen', unknown key 'canWrite', unknown key 'canQuickCreate', unknown key 'canCreateEdit', 'context' is missing (should be a object)
    Error: Invalid props for component 'X2ManyField': unknown key 'canCreate', unknown key 'canOpen', unknown key 'canWrite', unknown key 'canQuickCreate', unknown key 'canCreateEdit', 'context' is missing (should be a object)
        at Object.validateProps (http://localhost:17001/web/assets/debug/web.assets_web.js:10744:19) (/web/static/lib/owl/owl.js:3160)
        at X2Many2DMatrixRenderer.template (eval at compile (http://localhost:17001/web/assets/debug/web.assets_web.js:13283:20), <anonymous>:61:21) (/web/static/lib/owl/owl.js:5699)
        at Fiber._render (http://localhost:17001/web/assets/debug/web.assets_web.js:9313:38) (/web/static/lib/owl/owl.js:1729)
        at Fiber.render (http://localhost:17001/web/assets/debug/web.assets_web.js:9305:18) (/web/static/lib/owl/owl.js:1721)
        at ComponentNode.initiateRender (http://localhost:17001/web/assets/debug/web.assets_web.js:9985:23) (/web/static/lib/owl/owl.js:2401)
```

---

Not sure if this is correct way to fix it, but it seems that it works.

---

Thank you for you PR (https://github.com/OCA/web/pull/3117)